### PR TITLE
Hash として保存するために明示的に Hash 化する

### DIFF
--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -27,7 +27,7 @@ class Authentication < ApplicationRecord
       )
 
       acted_at = event.created_at
-      original_data = event.payload
+      original_data = event.payload.to_h
 
       activity.acted_at = acted_at
       activity.original_data = original_data


### PR DESCRIPTION
ここの payload は Hash によく似た Sawyer::Resource クラスのインスタンスで、こいつをそのまま渡しちゃうと Array として保存されてしまうようだった。明示的に Ruby の Hash に変換してから保存してあげると Array にならずに Hash として保存される。
