### PR TITLE
グラフのラベルも term_string を表示する

### DIFF
--- a/app/views/activities/on_term/index.html.slim
+++ b/app/views/activities/on_term/index.html.slim
@@ -63,7 +63,7 @@ javascript:
       type: 'bar',
 
       data: {
-        labels: ['今月のアクティビティ'],
+        labels: ['#{@term_string}のアクティビティ'],
         datasets: datasets
       },
 


### PR DESCRIPTION
マウスオーバーで表示されるグラフのラベルが4半期を表示する際も「今月」になっていたので直しました。