### PR TITLE
CI の結果を Slack に通知する処理を外す

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,19 +35,3 @@ jobs:
         env:
           RAILS_ENV: test
         run: bundle exec rspec
-      - name: Notify to Slack
-        uses: 8398a7/action-slack@v3
-        if: always()
-        with:
-          status: custom
-          fields: workflow,job,commit,repo,ref,author,took
-          custom_payload: |
-            {
-              attachments: [{
-                color: '${{ job.status }}' === 'success' ? 'good' : '${{ job.status }}' === 'failure' ? 'danger' : 'warning',
-                text: `${process.env.AS_WORKFLOW}\n${process.env.AS_JOB} (${process.env.AS_COMMIT}) of ${process.env.AS_REPO}@${process.env.AS_REF} by ${process.env.AS_AUTHOR} ${{ job.status }} in ${process.env.AS_TOOK}`,
-              }]
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
ここのところ CI の Slack 通知でなにかが起きていて、Lint や Test は問題ないのに CI の結果としては「失敗」となる事象が頻発している。しかも Job を Rerun すると何事もなかったかのように成功するケースもあって不穏。

煩わしいので、いったん Slack 通知の処理をまるっとなくしてみます。