### PR TITLE
常に最新の Brakeman を使う

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -10,6 +10,5 @@ jobs:
       - name: brakeman
         uses: reviewdog/action-brakeman@v1
         with:
-          brakeman_version: 4.8.2
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-review


### PR DESCRIPTION
https://github.com/sokusekiya/sokuseki/pull/373 にて https://github.com/reviewdog/action-brakeman の README にあるサンプルの YAML をコピーしてきて、Brakeman のバージョンを v4.8.2 に固定する書き方になっていたけれど、常に最新を使いたいので記述を消します。