### PR TITLE
開発環境を colima で立ち上げられるようにする

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -57,5 +57,5 @@ Rails.application.configure do
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
-  config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  config.file_watcher = ActiveSupport::FileUpdateChecker
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   database:
     image: postgres:10.4
     volumes:
-      - ./tmp/db:/var/lib/postgresql/data
+      - database-volume:/var/lib/postgresql/data
   web:
     build: .
     command: bash -c 'rm tmp/pids/server.pid 2>/dev/null; bundle exec rails server -b "0.0.0.0"'
@@ -20,4 +20,6 @@ services:
     stdin_open: true
 volumes:
   bundle-volume:
+    driver: local
+  database-volume:
     driver: local


### PR DESCRIPTION
Docker Desktop を脱却して colima に移行した人もいるだろうということで、対応します。
